### PR TITLE
Fixes OpenCLIP Embedding Function device issue.

### DIFF
--- a/chromadb/utils/embedding_functions/open_clip_embedding_function.py
+++ b/chromadb/utils/embedding_functions/open_clip_embedding_function.py
@@ -48,7 +48,8 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Union[Documents, Images]]):
             model_name=model_name, pretrained=checkpoint
         )
         self._model = model
-        self._model.to(device)
+        self._device = device
+        self._model.to(self._device)
         self._preprocess = preprocess
         self._tokenizer = open_clip.get_tokenizer(model_name=model_name)
 
@@ -56,14 +57,14 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Union[Documents, Images]]):
         pil_image = self._PILImage.fromarray(image)
         with self._torch.no_grad():
             image_features = self._model.encode_image(
-                self._preprocess(pil_image).unsqueeze(0)
+                self._preprocess(pil_image).unsqueeze(0).to(self._device)
             )
             image_features /= image_features.norm(dim=-1, keepdim=True)
             return cast(Embedding, image_features.squeeze().cpu().numpy())
 
     def _encode_text(self, text: Document) -> Embedding:
         with self._torch.no_grad():
-            text_features = self._model.encode_text(self._tokenizer(text))
+            text_features = self._model.encode_text(self._tokenizer(text).to(self._device)
             text_features /= text_features.norm(dim=-1, keepdim=True)
             return cast(Embedding, text_features.squeeze().cpu().numpy())
 


### PR DESCRIPTION
## Description of changes
to calculate the embedding vector on any other device than cpu
currently doesn't work because token and image input tensors are not transferred to the other device (ie. missing `.to(device)` calls

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - stores `device` in an attribute
   - adds `.to(self._device)` to the model inputs (in `_encode_image()` and `_encode_text()` methods)
 - New functionality
   - None

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

No changes are required as such.